### PR TITLE
Close the websocket when the Lex conversation completes

### DIFF
--- a/server.py
+++ b/server.py
@@ -111,7 +111,7 @@ class LexProcessor(object):
             info(r.headers)
             self.playback(r.content, id)
             if r.headers['x-amz-lex-session-attributes']:
-                if json.loads(r.headers['x-amz-lex-session-attributes'])).get('nexmo-close'):
+                if json.loads(r.headers['x-amz-lex-session-attributes']).get('nexmo-close'):
                     conns[id].close()
         else:
             info('Discarding {} frames'.format(str(count)))

--- a/server.py
+++ b/server.py
@@ -34,7 +34,7 @@ logging.captureWarnings(True)
 requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
 requests.packages.urllib3.disable_warnings(SNIMissingWarning)
 
-CLIP_MIN_MS = 500  # 500ms - the minimum audio clip that will be used
+CLIP_MIN_MS = 200  # 200ms - the minimum audio clip that will be used
 MAX_LENGTH = 10000  # Max length of a sound clip for processing in ms
 SILENCE = 20  # How many continuous frames of silence determine the end of a phrase
 
@@ -109,6 +109,8 @@ class LexProcessor(object):
             r = requests.post(endpoint, data=payload, headers=prepped.headers)
             info(r.headers)
             self.playback(r.content, id)
+            if r.headers['x-amz-lex-dialog-state'] == 'Fulfilled' or r.headers['x-amz-lex-dialog-state'] == 'Failed':
+                conns[id].close()
         else:
             info('Discarding {} frames'.format(str(count)))
     def playback(self, content, id):

--- a/server.py
+++ b/server.py
@@ -34,7 +34,7 @@ logging.captureWarnings(True)
 requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
 requests.packages.urllib3.disable_warnings(SNIMissingWarning)
 
-CLIP_MIN_MS = 200  # 200ms - the minimum audio clip that will be used
+CLIP_MIN_MS = 500  # 500ms - the minimum audio clip that will be used
 MAX_LENGTH = 10000  # Max length of a sound clip for processing in ms
 SILENCE = 20  # How many continuous frames of silence determine the end of a phrase
 

--- a/server.py
+++ b/server.py
@@ -23,6 +23,7 @@ import webrtcvad
 from requests_aws4auth import AWS4Auth
 from tornado.web import url
 import json
+from base64 import b64decode
 from requests.packages.urllib3.exceptions import InsecurePlatformWarning
 from requests.packages.urllib3.exceptions import SNIMissingWarning
 
@@ -109,8 +110,9 @@ class LexProcessor(object):
             r = requests.post(endpoint, data=payload, headers=prepped.headers)
             info(r.headers)
             self.playback(r.content, id)
-            if r.headers['x-amz-lex-dialog-state'] == 'Fulfilled' or r.headers['x-amz-lex-dialog-state'] == 'Failed':
-                conns[id].close()
+            if r.headers['x-amz-lex-session-attributes']:
+                if json.loads(r.headers['x-amz-lex-session-attributes'])).get('nexmo-close'):
+                    conns[id].close()
         else:
             info('Discarding {} frames'.format(str(count)))
     def playback(self, content, id):

--- a/server.py
+++ b/server.py
@@ -110,8 +110,8 @@ class LexProcessor(object):
             r = requests.post(endpoint, data=payload, headers=prepped.headers)
             info(r.headers)
             self.playback(r.content, id)
-            if r.headers['x-amz-lex-session-attributes']:
-                if json.loads(r.headers['x-amz-lex-session-attributes']).get('nexmo-close'):
+            if r.headers.get('x-amz-lex-session-attributes'):
+                if json.loads(b64decode(r.headers['x-amz-lex-session-attributes'])).get('nexmo-close'):
                     conns[id].close()
         else:
             info('Discarding {} frames'.format(str(count)))


### PR DESCRIPTION
When the `x-amz-lex-dialog-state` header is either `Fulfilled` or `Failed` then I think we can safely close the web socket and end the call, rather than waiting for the user to do so