### PR TITLE
200ms minimum clip to better support one-word interactions

### DIFF
--- a/server.py
+++ b/server.py
@@ -34,7 +34,7 @@ logging.captureWarnings(True)
 requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
 requests.packages.urllib3.disable_warnings(SNIMissingWarning)
 
-CLIP_MIN_MS = 500  # 500ms - the minimum audio clip that will be used
+CLIP_MIN_MS = 200  # 200ms - the minimum audio clip that will be used
 MAX_LENGTH = 10000  # Max length of a sound clip for processing in ms
 SILENCE = 20  # How many continuous frames of silence determine the end of a phrase
 


### PR DESCRIPTION
The previous 500ms minimum clip length was too long, in my testing, to pick up some single word interactions ("yes", "no")